### PR TITLE
Fix - non well formed numeric value for date type

### DIFF
--- a/lib/class-option-date.php
+++ b/lib/class-option-date.php
@@ -138,6 +138,19 @@ class TitanFrameworkOptionDate extends TitanFrameworkOption {
 		</script>
 		<?php
 	}
+        
+        /**
+	 * Return time() for specific date string value
+	 *
+	 * @return	void
+	 * @since	1.0
+	 */
+	public function getDateValueInTime() {
+            if ( empty( $this->getValue() ) ) {
+                return '';
+            }
+            return strtotime($this->getValue());
+        }
 
 
 	/**
@@ -164,7 +177,7 @@ class TitanFrameworkOptionDate extends TitanFrameworkOption {
 			$this->getID(),
 			$placeholder,
 			$this->getID(),
-			esc_attr( ($this->getValue() > 0) ? date( $dateFormat, $this->getValue() ) : '' ),
+			esc_attr( ($this->getValue() > 0) ? date( $dateFormat, $this->getDateValueInTime() ) : '' ),
 			$this->settings['desc']
 		);
 		$this->echoOptionFooter( false );


### PR DESCRIPTION
A fix for below mentioned notice issue:   
```
$panel->createOption( array(
        'name' => 'Finish',
        'id' => 'adv_end',
        'type' => 'date',
        'default' => '2017-04-10'
    ) );
```
Notice: A non well formed numeric value encountered in /var/www/html/wordpress/wp-content/plugins/titan-framework/lib/class-option-date.php on line 167